### PR TITLE
[cmake] remove usage of kodi-platform

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,18 +8,15 @@ enable_language(CXX)
 
 find_package(PkgConfig)
 find_package(Kodi REQUIRED)
-find_package(kodiplatform REQUIRED)
 find_package(p8-platform REQUIRED)
 find_package(RapidJSON REQUIRED)
 
-include_directories(${kodiplatform_INCLUDE_DIRS}
-                    ${p8-platform_INCLUDE_DIRS}
+include_directories(${p8-platform_INCLUDE_DIRS}
                     ${KODI_INCLUDE_DIR}
                     ${RAPIDJSON_INCLUDE_DIRS}
 )
 
-set(DEPLIBS ${kodiplatform_LIBRARIES} 
-            ${p8-platform_LIBRARIES}
+set(DEPLIBS ${p8-platform_LIBRARIES}
 )
 
 set(TELEBOY_SOURCES

--- a/debian/control
+++ b/debian/control
@@ -1,7 +1,7 @@
 Source: kodi-pvr-teleboy
 Priority: extra
 Maintainer: rbuehlma <rene@buehlmann.net>
-Build-Depends: debhelper (>= 9.0.0), cmake, pkg-config, libkodiplatform-dev (>= 17.1),
+Build-Depends: debhelper (>= 9.0.0), cmake, pkg-config,
                kodi-addon-dev, rapidjson-dev, libp8-platform-dev
 Standards-Version: 3.9.4
 Section: libs


### PR DESCRIPTION
The pvr.teleboy binary addon does not use kodi-platform.
Remove existing references from CMakeLists.txt and debian/control.

Signed-off-by: Olaf Hering <olaf@aepfle.de>