### PR TITLE
[pvr.teleboy] bump to 19.1.0

### DIFF
--- a/pvr.teleboy/addon.xml.in
+++ b/pvr.teleboy/addon.xml.in
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon id="pvr.teleboy"
-       version="19.0.0"
+       version="19.1.0"
        name="Teleboy PVR Client"
        provider-name="rbuehlma">
   <requires>@ADDON_DEPENDS@</requires>

--- a/pvr.teleboy/changelog.txt
+++ b/pvr.teleboy/changelog.txt
@@ -1,3 +1,5 @@
+v19.1.0
+ - Update to GUI addon API v5.14.0
 v19.0.0
  - Update to PVR addon API v6.0.0
 v18.0.24


### PR DESCRIPTION
Due to https://github.com/xbmc/xbmc/pull/16444 and GUI API breakage, a version bump is required

(only merge once the mentioned PR is merged)