### PR TITLE
[Matrix] API change updates

### DIFF
--- a/pvr.teleboy/addon.xml.in
+++ b/pvr.teleboy/addon.xml.in
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon id="pvr.teleboy"
-       version="19.4.8"
+       version="19.4.9"
        name="Teleboy PVR Client"
        provider-name="rbuehlma">
   <requires>
@@ -32,6 +32,8 @@
       <fanart>fanart.jpg</fanart>
     </assets>
     <news>
+v19.4.9
+- Update PVR API 6.5.0
 v19.4.8
 - Update PVR API 6.4.0
 - Correct license name on addon.xml

--- a/src/TeleBoy.cpp
+++ b/src/TeleBoy.cpp
@@ -269,7 +269,7 @@ bool TeleBoy::Login(string u, string p)
   return true;
 }
 
-void TeleBoy::GetAddonCapabilities(PVR_ADDON_CAPABILITIES* pCapabilities)
+void TeleBoy::GetCapabilities(PVR_ADDON_CAPABILITIES* pCapabilities)
 {
   pCapabilities->bSupportsRecordings = true;
   pCapabilities->bSupportsTimers = true;

--- a/src/TeleBoy.h
+++ b/src/TeleBoy.h
@@ -34,7 +34,7 @@ public:
   TeleBoy(bool favoritesOnly, bool enableDolby);
   virtual ~TeleBoy();
   virtual bool Login(string u, string p);
-  virtual void GetAddonCapabilities(PVR_ADDON_CAPABILITIES* pCapabilities);
+  virtual void GetCapabilities(PVR_ADDON_CAPABILITIES* pCapabilities);
   virtual int GetChannelsAmount(void);
   virtual PVR_ERROR GetChannels(ADDON_HANDLE handle, bool bRadio);
   virtual void TransferChannel(ADDON_HANDLE handle, TeleBoyChannel channel,

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -1,7 +1,6 @@
 #include "client.h"
 #include "TeleBoy.h"
 #include "kodi/xbmc_pvr_dll.h"
-#include "kodi/libKODI_guilib.h"
 #include <chrono>
 #include <thread>
 

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -204,7 +204,7 @@ void OnPowerSavingDeactivated()
 {
 }
 
-PVR_ERROR GetAddonCapabilities(PVR_ADDON_CAPABILITIES* pCapabilities)
+PVR_ERROR GetCapabilities(PVR_ADDON_CAPABILITIES* pCapabilities)
 {
   pCapabilities->bSupportsEPG = true;
   pCapabilities->bSupportsTV = true;
@@ -221,7 +221,7 @@ PVR_ERROR GetAddonCapabilities(PVR_ADDON_CAPABILITIES* pCapabilities)
   runningRequests++;
   if (teleboy)
   {
-    teleboy->GetAddonCapabilities(pCapabilities);
+    teleboy->GetCapabilities(pCapabilities);
   }
   runningRequests--;
   return PVR_ERROR_NO_ERROR;

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -699,7 +699,7 @@ PVR_ERROR SetEPGTimeFrame(int)
 {
   return PVR_ERROR_NOT_IMPLEMENTED;
 }
-PVR_ERROR GetDescrambleInfo(PVR_DESCRAMBLE_INFO*)
+PVR_ERROR GetDescrambleInfo(int channelUid, PVR_DESCRAMBLE_INFO*)
 {
   return PVR_ERROR_NOT_IMPLEMENTED;
 }
@@ -715,7 +715,7 @@ PVR_ERROR GetDriveSpace(long long *iTotal, long long *iUsed)
 {
   return PVR_ERROR_NOT_IMPLEMENTED;
 }
-PVR_ERROR SignalStatus(PVR_SIGNAL_STATUS &signalStatus)
+PVR_ERROR GetSignalStatus(int channelUid, PVR_SIGNAL_STATUS *signalStatus)
 {
   return PVR_ERROR_NOT_IMPLEMENTED;
 }

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -68,7 +68,7 @@ ADDON_STATUS ADDON_Create(void *hdl, void *props)
     return ADDON_STATUS_UNKNOWN;
   }
 
-  PVR_PROPERTIES *pvrprops = (PVR_PROPERTIES *) props;
+  AddonProperties_PVR *pvrprops = (AddonProperties_PVR *) props;
 
   XBMC = new CHelper_libXBMC_addon;
   XBMC->RegisterMe(hdl);


### PR DESCRIPTION
Related to xbmc/xbmc#17775 and to bring in after them.

Only startup and dll load test confirmed and OK, but with lack of server access not runtime tested.

This changes are mostly to prepare on Kodi itself for the coming rework to C++ PVR interface and to reduce his change size there.

Further and primary thought do fix part reported here xbmc/xbmc#17764 where his commit included in my Kodi request.

Question about this addon. I create a chart where all pvr addons in a table and to see what is different to others. So that a user can see within one page what are the difference between the much PVR addons on Kodi.
Like here I see:
- Internet stream (other addons, e.g. have own Hardware backend or own Software backend)
- Need account (that related website need user / password)
- Allow timers and recordings
- Allow HD streams
- Required depend addon "inputstream.adaptive"

As Questions:
- Does it only allow access from "CH" or from everywhere on world?
- Are there the created recordings available to download from somewhere?