### PR TITLE
Fully implement IsRealTimeStream()

### DIFF
--- a/pvr.teleboy/addon.xml.in
+++ b/pvr.teleboy/addon.xml.in
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon id="pvr.teleboy"
-       version="19.4.9"
+       version="19.4.10"
        name="Teleboy PVR Client"
        provider-name="rbuehlma">
   <requires>
@@ -32,6 +32,8 @@
       <fanart>fanart.jpg</fanart>
     </assets>
     <news>
+v19.4.10
+- Fully implement IsRealTimeStream()
 v19.4.9
 - Update PVR API 6.5.0
 v19.4.8

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -33,6 +33,7 @@ std::string teleboyPassword = "";
 bool teleboyFavoritesOnly = false;
 bool teleboyEnableDolby = true;
 int runningRequests = 0;
+bool isLivePlayback = false;
 
 extern "C"
 {
@@ -363,6 +364,7 @@ PVR_ERROR GetChannelStreamProperties(const PVR_CHANNEL* channel,
     setStreamProperties(properties, propertiesCount, strUrl);
     setStreamProperty(properties, propertiesCount, PVR_STREAM_PROPERTY_ISREALTIMESTREAM, "true");
     ret = PVR_ERROR_NO_ERROR;
+    isLivePlayback = true;
   }
   runningRequests--;
   return ret;
@@ -379,6 +381,7 @@ PVR_ERROR GetRecordingStreamProperties(const PVR_RECORDING* recording,
     *propertiesCount = 0;
     setStreamProperties(properties, propertiesCount, strUrl);
     ret = PVR_ERROR_NO_ERROR;
+    isLivePlayback = false;
   }
   runningRequests--;
   return ret;
@@ -537,6 +540,7 @@ PVR_ERROR GetEPGTagStreamProperties(const EPG_TAG* tag,
     *iPropertiesCount = 0;
     setStreamProperties(properties, iPropertiesCount, strUrl);
     ret = PVR_ERROR_NO_ERROR;
+    isLivePlayback = false;
   }
   runningRequests--;
   return ret;
@@ -671,7 +675,7 @@ unsigned int GetChannelSwitchDelay(void)
 }
 bool IsRealTimeStream(void)
 {
-  return true;
+  return isLivePlayback;
 }
 void PauseStream(bool bPaused)
 {


### PR DESCRIPTION
v19.4.10
- Fully implement IsRealTimeStream()

Can be merged once you are happy with the change and CI passes.

The change is related to a change in kodi whereby this function can be called when playing back a recording. If not correctly set the fast forward/rewind buttons can be missing.