### PR TITLE
Fully implement IsRealTimeStream() - Leia

### DIFF
--- a/pvr.teleboy/addon.xml.in
+++ b/pvr.teleboy/addon.xml.in
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon id="pvr.teleboy"
-       version="18.2.3"
+       version="18.2.4"
        name="Teleboy PVR Client"
        provider-name="rbuehlma">
   <requires>
@@ -26,6 +26,8 @@
     <disclaimer lang="en_US">The authors are in no way responsible for failed recordings, incorrect timers, wasted hours, or any other undesirable effects..</disclaimer>
     <platform>@PLATFORM@</platform>
     <news>
+v18.2.4
+- Fully implement IsRealTimeStream()
 v18.2.3
  - Fix cache cleanup
  - Prevent log flooding about missing categories

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -34,6 +34,7 @@ std::string teleboyPassword = "";
 bool teleboyFavoritesOnly = false;
 bool teleboyEnableDolby = true;
 int runningRequests = 0;
+bool isLivePlayback = false;
 
 extern "C"
 {
@@ -364,6 +365,7 @@ PVR_ERROR GetChannelStreamProperties(const PVR_CHANNEL* channel,
     setStreamProperties(properties, propertiesCount, strUrl);
     setStreamProperty(properties, propertiesCount, PVR_STREAM_PROPERTY_ISREALTIMESTREAM, "true");
     ret = PVR_ERROR_NO_ERROR;
+    isLivePlayback = true;
   }
   runningRequests--;
   return ret;
@@ -380,6 +382,7 @@ PVR_ERROR GetRecordingStreamProperties(const PVR_RECORDING* recording,
     *propertiesCount = 0;
     setStreamProperties(properties, propertiesCount, strUrl);
     ret = PVR_ERROR_NO_ERROR;
+    isLivePlayback = false;
   }
   runningRequests--;
   return ret;
@@ -538,6 +541,7 @@ PVR_ERROR GetEPGTagStreamProperties(const EPG_TAG* tag,
     *iPropertiesCount = 0;
     setStreamProperties(properties, iPropertiesCount, strUrl);
     ret = PVR_ERROR_NO_ERROR;
+    isLivePlayback = false;
   }
   runningRequests--;
   return ret;
@@ -668,7 +672,7 @@ bool IsTimeshifting(void)
 }
 bool IsRealTimeStream(void)
 {
-  return true;
+  return isLivePlayback;
 }
 void PauseStream(bool bPaused)
 {


### PR DESCRIPTION
v18.2.4
- Fully implement IsRealTimeStream()

The change is related to a change in kodi whereby this function can be called when playing back a recording. If not correctly set the fast forward/rewind buttons can be missing.

Don't merge and release just yet as we need to fix a Jenkins issue first for the Leia build.