### PR TITLE
Remove p8platform

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,15 +5,10 @@ set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${PROJECT_SOURCE_DIR})
 
 find_package(PkgConfig)
 find_package(Kodi REQUIRED)
-find_package(p8-platform REQUIRED)
 find_package(RapidJSON REQUIRED)
 
-include_directories(${p8-platform_INCLUDE_DIRS}
-                    ${KODI_INCLUDE_DIR}
+include_directories(${KODI_INCLUDE_DIR}
                     ${RAPIDJSON_INCLUDE_DIRS}
-)
-
-set(DEPLIBS ${p8-platform_LIBRARIES}
 )
 
 set(TELEBOY_SOURCES

--- a/depends/common/p8-platform/p8-platform.txt
+++ b/depends/common/p8-platform/p8-platform.txt
@@ -1,1 +1,0 @@
-p8-platform https://github.com/xbmc/platform.git cee64e9dc0b69e8d286dc170a78effaabfa09c44

--- a/depends/windowsstore/p8-platform/p8-platform.txt
+++ b/depends/windowsstore/p8-platform/p8-platform.txt
@@ -1,1 +1,0 @@
-p8-platform https://github.com/afedchin/platform.git win10

--- a/pvr.teleboy/addon.xml.in
+++ b/pvr.teleboy/addon.xml.in
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon id="pvr.teleboy"
-       version="19.6.0"
+       version="19.6.1"
        name="Teleboy PVR Client"
        provider-name="rbuehlma">
   <requires>
@@ -32,6 +32,11 @@
       <fanart>fanart.jpg</fanart>
     </assets>
     <news>
+v19.6.1
+ - Remove p8-platform dependency
+ - Use std::thread
+ - Use std:mutex
+ - Remove unused p8-platform headers
 v19.6.0
  - Update PVR API 7.0.0
  - Major changes to match new API
@@ -78,7 +83,7 @@ v19.3.5
  - Move changelog to addon metadata
 v19.3.4
  - Use Kodi epg categories
- - Add option to disable Dolby 
+ - Add option to disable Dolby
 v19.3.3
  - Use new stream api for replay and recordings
  - Support Dolby
@@ -124,7 +129,7 @@ v18.1.5
  - Move changelog to addon metadata
 v18.1.4
  - Use Kodi epg categories
- - Add option to disable Dolby 
+ - Add option to disable Dolby
 v18.1.3
  - Use new stream api for replay and recordings
  - Support Dolby

--- a/src/TeleBoy.cpp
+++ b/src/TeleBoy.cpp
@@ -30,7 +30,7 @@ static const string apiUrl = "https://tv.api.teleboy.ch";
 static const string apiDeviceType = "desktop";
 static const string apiVersion = "2.0";
 const char data_file[] = "special://profile/addon_data/pvr.teleboy/data.json";
-P8PLATFORM::CMutex TeleBoy::sendEpgToKodiMutex;
+std::mutex TeleBoy::sendEpgToKodiMutex;
 static const std::string user_agent = std::string("Kodi/")
     + std::string(STR(KODI_VERSION)) + std::string(" pvr.teleboy/")
     + std::string(STR(TELEBOY_VERSION)) + std::string(" (Kodi PVR addon)");
@@ -588,10 +588,7 @@ void TeleBoy::GetEPGForChannelAsync(int uniqueChannelId, time_t iStart,
     totals = json["data"]["total"].GetInt();
     const Value& items = json["data"]["items"];
 
-    if (!sendEpgToKodiMutex.Lock()) {
-      kodi::Log(ADDON_LOG_ERROR, "Failed to lock sendEpgToKodiMutex.");
-      return;
-    }
+    std::lock_guard<std::mutex> lock(sendEpgToKodiMutex);
 
     for (Value::ConstValueIterator itr1 = items.Begin(); itr1 != items.End();
         ++itr1)
@@ -639,7 +636,6 @@ void TeleBoy::GetEPGForChannelAsync(int uniqueChannelId, time_t iStart,
 
       EpgEventStateChange(tag, EPG_EVENT_CREATED);
     }
-    sendEpgToKodiMutex.Unlock();
     kodi::Log(ADDON_LOG_DEBUG, "Loaded %i of %i epg entries for channel %i.", sum,
         totals, uniqueChannelId);
   }

--- a/src/TeleBoy.cpp
+++ b/src/TeleBoy.cpp
@@ -10,7 +10,6 @@
 #include <iostream>
 #include <string>
 #include <sstream>
-#include "p8-platform/sockets/tcp.h"
 #include <map>
 #include <time.h>
 #include <random>

--- a/src/TeleBoy.cpp
+++ b/src/TeleBoy.cpp
@@ -167,7 +167,6 @@ TeleBoy::~TeleBoy()
 {
   for (auto const &updateThread : updateThreads)
   {
-    updateThread->StopThread(200);
     delete updateThread;
   }
 }

--- a/src/TeleBoy.h
+++ b/src/TeleBoy.h
@@ -74,7 +74,7 @@ private:
   string apiKey;
   map<int, TeleBoyChannel> channelsById;
   map<int, TeleboyGenre> genresById;
-  static P8PLATFORM::CMutex sendEpgToKodiMutex;
+  static std::mutex sendEpgToKodiMutex;
   vector<int> sortedChannels;
   int64_t maxRecallSeconds;
   vector<UpdateThread*> updateThreads;

--- a/src/UpdateThread.cpp
+++ b/src/UpdateThread.cpp
@@ -14,7 +14,6 @@ time_t UpdateThread::nextRecordingsUpdate;
 std::mutex UpdateThread::mutex;
 
 UpdateThread::UpdateThread(int threadIdx, TeleBoy& teleboy) :
-    CThread(),
     m_teleboy(teleboy),
     m_threadIdx(threadIdx)
 {
@@ -56,7 +55,7 @@ void UpdateThread::LoadEpg(int uniqueChannelId, time_t startTime,
   loadEpgQueue.push(entry);
 }
 
-void* UpdateThread::Process()
+void UpdateThread::Process()
 {
   kodi::Log(ADDON_LOG_DEBUG, "Update thread started.");
   while (m_running)

--- a/src/UpdateThread.cpp
+++ b/src/UpdateThread.cpp
@@ -5,11 +5,13 @@
 
 #include "kodi/General.h"
 
+#include <chrono>
+
 const time_t maximumUpdateInterval = 600;
 
 std::queue<EpgQueueEntry> UpdateThread::loadEpgQueue;
 time_t UpdateThread::nextRecordingsUpdate;
-P8PLATFORM::CMutex UpdateThread::mutex;
+std::mutex UpdateThread::mutex;
 
 UpdateThread::UpdateThread(int threadIdx, TeleBoy& teleboy) :
     CThread(),
@@ -18,29 +20,27 @@ UpdateThread::UpdateThread(int threadIdx, TeleBoy& teleboy) :
 {
   time(&UpdateThread::nextRecordingsUpdate);
   UpdateThread::nextRecordingsUpdate += maximumUpdateInterval;
-  CreateThread(false);
+
+  m_running = true;
+  m_thread = std::thread([&] { Process(); });
 }
 
 UpdateThread::~UpdateThread()
 {
-
+  m_running = false;
+  if (m_thread.joinable())
+    m_thread.join();
 }
 
 void UpdateThread::SetNextRecordingUpdate(time_t nextRecordingsUpdate)
 {
   if (nextRecordingsUpdate < UpdateThread::nextRecordingsUpdate)
   {
-    if (!mutex.Lock())
-    {
-      kodi::Log(ADDON_LOG_ERROR,
-          "UpdateThread::SetNextRecordingUpdate : Could not lock mutex.");
-      return;
-    }
+    std::lock_guard<std::mutex> lock(mutex);
     if (nextRecordingsUpdate < UpdateThread::nextRecordingsUpdate)
     {
       UpdateThread::nextRecordingsUpdate = nextRecordingsUpdate;
     }
-    mutex.Unlock();
   }
 }
 
@@ -51,22 +51,18 @@ void UpdateThread::LoadEpg(int uniqueChannelId, time_t startTime,
   entry.uniqueChannelId = uniqueChannelId;
   entry.startTime = startTime;
   entry.endTime = endTime;
-  if (!mutex.Lock())
-  {
-    kodi::Log(ADDON_LOG_ERROR, "UpdateThread::LoadEpg : Could not lock mutex.");
-    return;
-  }
+
+  std::lock_guard<std::mutex> lock(mutex);
   loadEpgQueue.push(entry);
-  mutex.Unlock();
 }
 
 void* UpdateThread::Process()
 {
   kodi::Log(ADDON_LOG_DEBUG, "Update thread started.");
-  while (!IsStopped())
+  while (m_running)
   {
-    Sleep(100);
-    if (IsStopped())
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    if (!m_running)
     {
       continue;
     }
@@ -77,23 +73,14 @@ void* UpdateThread::Process()
 
     while (!loadEpgQueue.empty())
     {
-      if (!mutex.Lock())
-      {
-        kodi::Log(ADDON_LOG_ERROR,
-            "UpdateThread::Process : Could not lock mutex for epg queue");
-        break;
-      }
+      std::unique_lock<std::mutex> lock(mutex);
       if (!loadEpgQueue.empty())
       {
         EpgQueueEntry entry = loadEpgQueue.front();
         loadEpgQueue.pop();
-        mutex.Unlock();
+        lock.unlock();
         m_teleboy.GetEPGForChannelAsync(entry.uniqueChannelId,
             entry.startTime, entry.endTime);
-      }
-      else
-      {
-        mutex.Unlock();
       }
     }
 
@@ -102,29 +89,19 @@ void* UpdateThread::Process()
 
     if (currentTime >= UpdateThread::nextRecordingsUpdate)
     {
-      if (!mutex.Lock())
-      {
-        kodi::Log(ADDON_LOG_ERROR,
-            "UpdateThread::Process : Could not lock mutex for recordings update");
-        continue;
-      }
+      std::unique_lock<std::mutex> lock(mutex);
       if (currentTime >= UpdateThread::nextRecordingsUpdate)
       {
         UpdateThread::nextRecordingsUpdate = currentTime
             + maximumUpdateInterval;
-        mutex.Unlock();
+        lock.unlock();
         m_teleboy.TriggerTimerUpdate();
         m_teleboy.TriggerRecordingUpdate();
         kodi::Log(ADDON_LOG_DEBUG, "Update thread triggered update.");
-      }
-      else
-      {
-        mutex.Unlock();
       }
     }
   }
 
   kodi::Log(ADDON_LOG_DEBUG, "Update thread stopped.");
-  return nullptr;
 }
 

--- a/src/UpdateThread.h
+++ b/src/UpdateThread.h
@@ -1,8 +1,9 @@
 #pragma once
 
-#include <p8-platform/threads/threads.h>
-#include <p8-platform/threads/mutex.h>
+#include <atomic>
+#include <mutex>
 #include <queue>
+#include <thread>
 
 class TeleBoy;
 
@@ -13,19 +14,21 @@ struct EpgQueueEntry
   time_t endTime;
 };
 
-class UpdateThread: public P8PLATFORM::CThread
+class UpdateThread
 {
 public:
   UpdateThread(int threadIdx, TeleBoy& teleboy);
-  ~UpdateThread() override;
+  ~UpdateThread();
   static void SetNextRecordingUpdate(time_t nextRecordingsUpdate);
   static void LoadEpg(int uniqueChannelId, time_t startTime, time_t endTime);
-  void* Process() override;
+  void Process();
 
 private:
   TeleBoy& m_teleboy;
   int m_threadIdx;
   static std::queue<EpgQueueEntry> loadEpgQueue;
   static time_t nextRecordingsUpdate;
-  static P8PLATFORM::CMutex mutex;
+  std::atomic<bool> m_running = {false};
+  std::thread m_thread;
+  static std::mutex mutex;
 };

--- a/src/Utils.cpp
+++ b/src/Utils.cpp
@@ -9,7 +9,6 @@
 #include <sstream>
 
 #include "kodi/Filesystem.h"
-#include "p8-platform/os.h"
 
 std::string Utils::GetFilePath(std::string strPath, bool bUserPath)
 {

--- a/src/categories.cpp
+++ b/src/categories.cpp
@@ -22,7 +22,6 @@
 
 #include "categories.h"
 #include <cstring>
-#include <p8-platform/os.h>
 #include <regex>
 
 #include "kodi/Filesystem.h"


### PR DESCRIPTION
v19.6.1
 - Remove p8-platform dependency
 - Use std::thread
 - Use std:mutex
 - Remove unused p8-platform headers