### PR TITLE
Remove p8 from debian control file - v19.6.2

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: kodi-pvr-teleboy
 Priority: extra
 Maintainer: rbuehlma <rene@buehlmann.net>
 Build-Depends: debhelper (>= 9.0.0), cmake, pkg-config,
-               kodi-addon-dev, rapidjson-dev, libp8-platform-dev
+               kodi-addon-dev, rapidjson-dev
 Standards-Version: 4.1.2
 Section: libs
 Homepage: http://kodi.tv

--- a/pvr.teleboy/addon.xml.in
+++ b/pvr.teleboy/addon.xml.in
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon id="pvr.teleboy"
-       version="19.6.1"
+       version="19.6.2"
        name="Teleboy PVR Client"
        provider-name="rbuehlma">
   <requires>
@@ -32,6 +32,8 @@
       <fanart>fanart.jpg</fanart>
     </assets>
     <news>
+v19.6.2
+- Remove p8 from debian control file
 v19.6.1
  - Remove p8-platform dependency
  - Use std::thread


### PR DESCRIPTION
v19.6.2
- Remove p8 from debian control file