### PR TITLE
Add change and release workflow for update automation

### DIFF
--- a/.github/workflows/changelog-and-release.yml
+++ b/.github/workflows/changelog-and-release.yml
@@ -1,0 +1,120 @@
+name: Changelog and Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version_type:
+        description: 'Create a ''minor'' or ''micro'' release?'
+        required: true
+        default: 'minor'
+      changelog_text:
+        description: 'Input the changes you''d like to add to the changelogs. Your text should be encapsulated in "''s with line feeds represented by literal \n''s. ie. "This is the first change\nThis is the second change"'
+        required: true
+        default: ''
+      update_news:
+        description: 'Update news in addon.xml.in? [true|false]'
+        required: true
+        default: 'true'
+      add_date:
+        description: 'Add date to version number in changelog and news. ie. "v1.0.1 (2021-7-17)" [true|false]'
+        required: true
+        default: 'false'
+
+jobs:
+  default:
+    runs-on: ubuntu-latest
+    name: Changelog and Release
+
+    steps:
+
+      - name: Checkout Repository
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+          path: ${{ github.event.repository.name }}
+
+      - name: Checkout Scripts
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+          repository: kodi-pvr/pvr-scripts
+          path: scripts
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get install libxml2-utils xmlstarlet
+
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.9'
+
+      - name: Increment version and update changelogs
+        run: |
+          arguments=
+          if [[ ${{ github.event.inputs.update_news }} == true ]] ;
+          then
+            arguments=$(echo $arguments && echo --update-news)
+          fi
+          if [[ ${{ github.event.inputs.add_date }} == true ]] ;
+          then
+            arguments=$(echo $arguments && echo --add-date)
+          fi
+          python3 ../scripts/changelog_and_release.py ${{ github.event.inputs.version_type }} ${{ github.event.inputs.changelog_text }} $arguments
+        working-directory: ${{ github.event.repository.name }}
+
+      - name: Get required variables
+        id: required-variables
+        run: |
+          changes=$(cat "$(find . -name changelog.txt)" | awk -v RS= 'NR==1')
+          if [ -z "$changes" ] ;
+          then
+            changes=$(xmlstarlet fo -R "$(find . -name addon.xml.in)" | xmlstarlet sel -t -v 'string(/addon/extension/news)' | awk -v RS= 'NR==1')
+          fi
+          changes="${changes//'%'/'%25'}"
+          changes="${changes//$'\n'/'%0A'}"
+          changes="${changes//$'\r'/'%0D'}"
+          changes="${changes//$'\\n'/'%0A'}"
+          changes="${changes//$'\\r'/'%0D'}"
+          echo ::set-output name=changes::$changes
+          version=$(xmlstarlet fo -R "$(find . -name addon.xml.in)" | xmlstarlet sel -t -v 'string(/addon/@version)')
+          echo ::set-output name=version::$version
+          branch=$(echo ${GITHUB_REF#refs/heads/})
+          echo ::set-output name=branch::$branch
+          echo ::set-output name=today::$(date +'%Y-%m-%d')
+        working-directory: ${{ github.event.repository.name }}
+
+      - name: Commit changes
+        run: |
+          git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config --local user.name "github-actions[bot]"
+          commit_message="changelog and version v${{ steps.required-variables.outputs.version }}"
+          if [[ ${{ github.event.inputs.add_date }} == true ]] ;
+          then
+            commit_message="$commit_message (${{ steps.required-variables.outputs.today }})"
+          fi
+          git commit -m "$commit_message" -a
+        working-directory: ${{ github.event.repository.name }}
+
+      - name: Push changes
+        uses: ad-m/github-push-action@master
+        with:
+          branch: ${{ github.ref }}
+          directory: ${{ github.event.repository.name }}
+
+      - name: Sleep for 60 seconds
+        run: sleep 60s
+        shell: bash
+
+      - name: Create Release
+        id: create-release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ steps.required-variables.outputs.version }}-${{ steps.required-variables.outputs.branch }}
+          release_name: ${{ steps.required-variables.outputs.version }}-${{ steps.required-variables.outputs.branch }}
+          body: ${{ steps.required-variables.outputs.changes }}
+          draft: false
+          prerelease: false
+          commitish: ${{ steps.required-variables.outputs.branch }}


### PR DESCRIPTION
*DO NOT MERGE YET*

This workflow should allow easier kodi PVR API updates being triggered by the `gh` command locally on a dev machine. The hope is to automate API updates across all of PVR add-ons to reduce the maintenance burden.

First step is to test if it works. Note: The commands below will create a full release automatically.

After merge this can be done by installing the `gh` command and then trying to run:

1. `gh auto login` (https via a web browser should be fine)
2. `gh --repo rbuehlma/pvr.teleboy --ref Matrix workflow run changelog-and-release.yml -f version_type=micro -f update_news=true -f changelog_text="-\ Release bump\\\n-\ Automation testing"`

*The above command will update the micro version number and add the changelog text where appropriate. Then a release will be created using the same details*