### PR TITLE
[Nexus] Add supports recordings delete capability for PVR API 8.0.0

### DIFF
--- a/pvr.teleboy/addon.xml.in
+++ b/pvr.teleboy/addon.xml.in
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon id="pvr.teleboy"
-       version="20.0.0"
+       version="20.1.0"
        name="Teleboy PVR Client"
        provider-name="rbuehlma">
   <requires>
@@ -32,6 +32,10 @@
       <fanart>fanart.jpg</fanart>
     </assets>
     <news>
+v20.1.0
+- Kodi PVR API to 8.0.0
+  - Add supports recordings delete capability
+  - Enforce EDL limits
 v20.0.0
  - Adapt for Kodi 20 Nexus
 v19.8.1

--- a/src/TeleBoy.cpp
+++ b/src/TeleBoy.cpp
@@ -351,6 +351,7 @@ PVR_ERROR TeleBoy::GetCapabilities(kodi::addon::PVRCapabilities& capabilities)
   capabilities.SetSupportsEPGEdl(true);
   capabilities.SetSupportsRecordingEdl(true);
   capabilities.SetSupportsRecordings(true);
+  capabilities.SetSupportsRecordingsDelete(true);
   capabilities.SetSupportsTimers(true);
 
   return PVR_ERROR_NO_ERROR;


### PR DESCRIPTION
- Kodi API to 8.0.0
  - Following in API change (not all affect addon):
    - Add supports recordings delete capability
    - Add support for PVR Providers and parental rating code for EPG
    - Enforce EDL limits

**WARNING:** Merge after the requests on Kodi are in.

This PR should be rebuilt via Jenkins after these xbmc PRs are merged:
- https://github.com/xbmc/xbmc/pull/20009
- https://github.com/xbmc/xbmc/pull/19395