### PR TITLE
ci: bump actions/checkout from v4 to v6

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,13 +24,13 @@ jobs:
         if [[ $DEBIAN_BUILD == true ]]; then sudo apt-get update; fi
         if [[ $DEBIAN_BUILD == true ]]; then sudo apt-get install fakeroot; fi
     - name: Checkout Kodi repo
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         repository: xbmc/xbmc
         ref: master
         path: xbmc
     - name: Checkout add-on repo
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         path: ${{ env.app_id }}
     - name: Configure


### PR DESCRIPTION
Node.js 20 actions are deprecated and will be forced to Node.js 24 starting June 16th 2026. actions/checkout v6 runs on Node.js 24.